### PR TITLE
Fixing the Title

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,7 +78,7 @@ const config = {
           {
             to: '/terranetes-controller',
             position: 'left',
-            label: 'Terraform Controller',
+            label: 'Terranetes Controller',
           },
           {
             to: '/tf2helm',


### PR DESCRIPTION
We were still using the old name at the top of the page
