### PR TITLE
link to applied remote resources

### DIFF
--- a/docs/terranetes-controller/quick_start.md
+++ b/docs/terranetes-controller/quick_start.md
@@ -8,7 +8,7 @@ Before we begin, you'll need the following tools:
 * **[Helm CLI](https://helm.sh/docs/intro/install/)**
 * **[Kind](https://kind.sigs.k8s.io/)**
 
-The quickest way to get up and running is via the [Helm chart:][tn_chart]
+The quickest way to get up and running is via the Helm chart (see [chart][tn_chart]):
 
 ```bash
 $ helm repo add appvia https://terranetes-controller.appvia.io
@@ -20,7 +20,7 @@ $ kubectl -n terraform-system get pods
 
 ## Configure credentials
 
-Next, we configure some [cloud credentials][ex_provider] to run terraform with:
+Next, we configure some cloud credentials to run terraform with (see [provider.yaml][ex_provider]):
 
 :::info
 The following assumes you are using static cloud credentials. See the docs for [**managed pod identity**](/terranetes-controller/admin/providers/#configure-injected-identity).
@@ -39,7 +39,7 @@ See [Configure Credentials](/docs/terranetes-controller/admin/providers.md) for 
 
 ## Create your first terraform resource
 
-Retrieve a [demo configuration][ex_configuration] that creates an S3 bucket.
+Retrieve a demo configuration that creates an S3 bucket (see [configuration.yaml][ex_configuration]).
 
 ```bash
 wget https://raw.githubusercontent.com/appvia/terranetes-controller/master/examples/configuration.yaml

--- a/docs/terranetes-controller/quick_start.md
+++ b/docs/terranetes-controller/quick_start.md
@@ -20,7 +20,7 @@ $ kubectl -n terraform-system get pods
 
 ## Configure credentials
 
-Next, we configure some cloud credentials to run terraform with:
+Next, we configure some [cloud credentials][ex_provider] to run terraform with:
 
 :::info
 The following assumes you are using static cloud credentials. See the docs for [**managed pod identity**](/terranetes-controller/admin/providers/#configure-injected-identity).
@@ -39,7 +39,7 @@ See [Configure Credentials](/docs/terranetes-controller/admin/providers.md) for 
 
 ## Create your first terraform resource
 
-Retrieve a demo configuration that creates an S3 bucket.
+Retrieve a [demo configuration][ex_configuration] that creates an S3 bucket.
 
 ```bash
 wget https://raw.githubusercontent.com/appvia/terranetes-controller/master/examples/configuration.yaml
@@ -96,3 +96,5 @@ $ kubectl -n apps delete configuration bucket
 
 Tailing the logs from the watcher will allow you to view the execution.
 
+[ex_provider]: https://github.com/appvia/terranetes-controller/blob/master/examples/provider.yaml
+[ex_configuration]: https://github.com/appvia/terranetes-controller/blob/master/examples/configuration.yaml

--- a/docs/terranetes-controller/quick_start.md
+++ b/docs/terranetes-controller/quick_start.md
@@ -8,7 +8,7 @@ Before we begin, you'll need the following tools:
 * **[Helm CLI](https://helm.sh/docs/intro/install/)**
 * **[Kind](https://kind.sigs.k8s.io/)**
 
-The quickest way to get up and running is via the Helm chart:
+The quickest way to get up and running is via the [Helm chart:][tn_chart]
 
 ```bash
 $ helm repo add appvia https://terranetes-controller.appvia.io
@@ -96,5 +96,6 @@ $ kubectl -n apps delete configuration bucket
 
 Tailing the logs from the watcher will allow you to view the execution.
 
+[tn_chart]: https://github.com/appvia/terranetes-controller/tree/master/charts/terranetes-controller
 [ex_provider]: https://github.com/appvia/terranetes-controller/blob/master/examples/provider.yaml
 [ex_configuration]: https://github.com/appvia/terranetes-controller/blob/master/examples/configuration.yaml


### PR DESCRIPTION
As a user who wants to try out new tools, I really hate the practice of giving examples like
```
$ kubectl apply -f https://raw.githubusercontent.com/appvia/terranetes-controller/master/examples/provider.yaml
```
in Quick Start-type guides without giving me an easy way to view this file before I apply it to one of my clusters. It's often substantially slower and more fiddly to select/copy/paste the link from the example, especially if it scrolls off the page. For reference, I tend to browse using vimium (or an equivalent for other browsers), so opening up that link in a separate tab to view the file as I work through the example is easy without leaving the keyboard. I imagine lots of other developers use some other equivalent workflow. I may also want to start downloading the files & thinking about how I'm going to integrate them into a deployment setup that fits how I manage my other k8s stuff, and for that I probably want to download the file, and basically it just makes sense to link me to the repo.

So I added links to the two files applied in the example, and to the helm chart. I'm hoping if more projects start doing this it will catch on.

Notes:

1. As you see I've used reference-style links instead of inline links. I guess I could have used inline links like the rest of the document, although I do think they make everything much less readable. I'll change this if maintainers prefer. Personally, I think everyone should switch to using 100% reference-style links, but I won't force my views on the maintainers.
2. I'm not 100% certain this is the absolute best way to write this. For example, another option would be to write something like
```
Next, we configure some cloud credentials to run terraform with (see [provider.yaml][ex_provider])
```
which arguably makes it more clear what the link is about: showing you what's in the example file you're about to apply to your cluster. Please tell me which approach you prefer.