### PR TITLE
Dropping Reference to tf2helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Terranetes
 
-## Components 
+## Components
 
 * Terraform Controller https://github.com/appvia/terranetes-controller
-* tf2helm https://github.com/appvia/tf2helm
 
 **Access the docs at https://terranetes.appvia.io**

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,11 +81,6 @@ const config = {
             label: 'Terranetes Controller',
           },
           {
-            to: '/tf2helm',
-            position: 'left',
-            label: 'tf2helm',
-          },
-          {
             href: 'https://github.com/appvia/terranetes-controller',
             label: 'GitHub',
             position: 'right',


### PR DESCRIPTION
Removing all the links to tf2helm (keeping the docs however for now)
