### PR TITLE
When annotating a Configuration, specify the 'overwrite' flag

### DIFF
--- a/docs/terranetes-controller/developer/configuration.md
+++ b/docs/terranetes-controller/developer/configuration.md
@@ -159,7 +159,7 @@ By default, unless the `spec.enableAutoApproval` is set to true, all Configurati
 To approve the Configuration `bucket`:
 
 ```shell
-$ kubectl -n apps annotate configurations bucket "terraform.appvia.io/apply"=true
+$ kubectl -n apps annotate configurations bucket "terraform.appvia.io/apply"=true --overwrite
 ```
 
 ## Deleting the resource


### PR DESCRIPTION
You receive the following from kubectl if this is not done:
```
error: --overwrite is false but found the following declared annotation(s): 'terraform.appvia.io/apply' already has a value (false)
```