### PR TITLE
Fixing Typo on Releases

### DIFF
--- a/docs/terranetes-controller/releases.md
+++ b/docs/terranetes-controller/releases.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Releases
 
-## Release v0.3.22
+## Release v0.3.23
 
 ### Terranetes CLI (tnctl)
 


### PR DESCRIPTION
Got a version typo on the releases page
